### PR TITLE
Passing application-dependent parameters to queries

### DIFF
--- a/seep-common/src/main/java/uk/ac/imperial/lsds/seep/config/CommandLineArgs.java
+++ b/seep-common/src/main/java/uk/ac/imperial/lsds/seep/config/CommandLineArgs.java
@@ -1,13 +1,13 @@
 package uk.ac.imperial.lsds.seep.config;
 
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Properties;
-
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import uk.ac.imperial.lsds.seep.config.ConfigDef.Type;
+
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Properties;
 
 public class CommandLineArgs {
 
@@ -81,4 +81,13 @@ public class CommandLineArgs {
     	}
     	return value;
     }
+
+	/**
+	 * Gets the command line arguments that are for the query
+	 * (all the arguments that were not specified to the parser to accept)
+	 * @return array of query command line arguments
+	 */
+	public String[] getQueryArgs() {
+		return options.nonOptionArguments().toArray(new String[0]);
+	}
 }


### PR DESCRIPTION
- Allowing unrecognized options from the command line
- Pass these options to the Base class constructor so as not to change the QueryComposer interface and break existing queries
- When constructing the instance of the base class, the constructor that takes a string array as the only argument is used if it exists, otherwise the default constructor is used

USAGE:
To be able to pass parameters to queries:
- Create a constructor in the Base class with the following signature: `public Base(String[] args) {...}`
- `args` has the form of [option, value, option, value ...] which can be parsed by an option parser such as Jopt Simple
- Pass the query options to the master jar 

E.g. Addding extra option `--file.path /foo/bar` when running the master jar will pass `["file.path", "/foo/bar"]` as `args` to Base 
