### PR TITLE
SDG enum extra functionality to automate annotation parsing in AnalysisUtils

### DIFF
--- a/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/analysis/AnalysisUtils.java
+++ b/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/analysis/AnalysisUtils.java
@@ -11,39 +11,7 @@ public class AnalysisUtils {
 		Type type = annotation.getType();
 		String typeStr = type.toString();
 		
-		// FIXME: get names and types from the enum so that this is always automatic
-		
-		if(typeStr.equals("Partitioned")){
-			return SDGAnnotation.PARTITIONED;
-		}
-		else if(typeStr.equals("Partial")){
-			return SDGAnnotation.PARTIAL_STATE;
-		}
-		else if(typeStr.equals("PartialState")){
-			return SDGAnnotation.PARTIAL_STATE;
-		}
-		else if(typeStr.equals("PartialData")){
-			return SDGAnnotation.PARTIAL_DATA;
-		}
-		else if(typeStr.equals("Global")){
-			return SDGAnnotation.GLOBAL;
-		}
-		else if(typeStr.equals("Collection")){
-			return SDGAnnotation.COLLECTION;
-		}
-		else if(typeStr.equals("Collection")){
-			return SDGAnnotation.COLLECTION;
-		}
-		else if(typeStr.equals("NetworkSource")){
-			return SDGAnnotation.NETWORKSOURCE;
-		}
-		else if(typeStr.equals("File")){
-			return SDGAnnotation.FILE;
-		}
-		else if(typeStr.equals("ConsoleSink")){
-			return SDGAnnotation.CONSOLESINK;
-		}
-		return null;
+		return SDGAnnotation.getAnnotation(typeStr);
 	}
 	
 }

--- a/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/bricks/SDGAnnotation.java
+++ b/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/bricks/SDGAnnotation.java
@@ -11,10 +11,42 @@
 package uk.ac.imperial.lsds.java2sdg.bricks;
 
 public enum SDGAnnotation{
-	PARTITIONED, 
-	PARTIAL_STATE, 
-	PARTIAL_DATA, 
-	GLOBAL,
+	PARTITIONED ("Partitioned"), 
+	PARTIAL_STATE ("PartialState"), 
+	PARTIAL_DATA ("PartialData"), 
+	GLOBAL ("Global"),
+	GLOBAL_WRITE ("GlobalWrite"),
+	GLOBAL_READ ("GlobalRead"),
+	COLLECTION ("Collection"),
+	LOCAL ("Local"),
+	FILE ("File"),
+	NETWORKSOURCE ("NetworkSource"),
+	CONSOLESINK ("ConsoleSink");
 	
-	GLOBAL_WRITE, GLOBAL_READ, COLLECTION, LOCAL, FILE, NETWORKSOURCE, CONSOLESINK
+	
+	private final String value;
+	
+	private SDGAnnotation(String v) {
+		value = v;
+	}
+	
+	public String getValue(){
+		return value;
+	}
+	/*
+	 * Method to automatically identify  annotation from its representation
+	 * Partial seems to be the same case as Partial_State so there is an extra condition
+	 * This methods throws an IllegalArgumentException if the value is not an acceptable Annotation  
+	 */
+	public static SDGAnnotation getAnnotation(String value) {
+		
+		if(value.equalsIgnoreCase("Partial"))
+			return SDGAnnotation.PARTIAL_STATE;
+		
+        for(SDGAnnotation v : values())
+            if(v.getValue().equalsIgnoreCase(value)) 
+            	return v;
+        throw new IllegalArgumentException();
+    }
+	
 }


### PR DESCRIPTION
Added extra functionality to support automatic annotation parsing in AnalysisUtils.
Partial and Partial State string return the same Enum so there is an extra condition, if the string is not recognised there is an exception.
Code tested and working.
