### PR TITLE
Code to analyse the Collection annotation in method declarations

### DIFF
--- a/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/ConductorUtils.java
+++ b/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/ConductorUtils.java
@@ -5,8 +5,9 @@ import java.io.IOException;
 
 import org.codehaus.commons.compiler.CompileException;
 import org.codehaus.janino.Java;
-import org.codehaus.janino.Parser;
 import org.codehaus.janino.Scanner;
+
+import uk.ac.imperial.lsds.java2sdg.analysis.CustomParser;
 
 public class ConductorUtils {
 
@@ -14,7 +15,7 @@ public class ConductorUtils {
 		Java.CompilationUnit cu = null;
 		try{
 			FileReader r = new FileReader(inputFile);
-			cu = new Parser(new Scanner(inputFile, r)).parseCompilationUnit();
+			cu = new CustomParser(new Scanner(inputFile, r)).parseCompilationUnit();
 		}
 		catch(IOException io) {
 			io.printStackTrace();

--- a/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/analysis/AnnotationAnalysis.java
+++ b/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/analysis/AnnotationAnalysis.java
@@ -12,7 +12,7 @@ import uk.ac.imperial.lsds.java2sdg.bricks.SDGAnnotation;
 public class AnnotationAnalysis extends Traverser {
 
 	private AnalysisUtils au = new AnalysisUtils();
-	private Map<Integer, SDGAnnotation> anns = new HashMap<>();
+	private static Map<Integer, SDGAnnotation> anns = new HashMap<>();
 	
 	public static Map<Integer, SDGAnnotation> getAnnotations(Java.CompilationUnit cu){
 		AnnotationAnalysis aa = new AnnotationAnalysis();
@@ -40,6 +40,14 @@ public class AnnotationAnalysis extends Traverser {
         }
 	}
 	
-	// TODO: write a visitor for methods so that we can retrieve Collection annotation
+	
+	public static void addCustomParserCollectionAnnotation(int line, String annotation){
+		/*
+		 * The line should be replaced after the merge with:
+		 * AnnotationAnalysis.anns.put(line, SDGAnnotation.getAnnotation(annotation));
+		 */
+		AnnotationAnalysis.anns.put(line, SDGAnnotation.COLLECTION);
+		
+	}
 	
 }

--- a/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/analysis/CustomParser.java
+++ b/seep-java2sdg/src/main/java/uk/ac/imperial/lsds/java2sdg/analysis/CustomParser.java
@@ -1,0 +1,37 @@
+package uk.ac.imperial.lsds.java2sdg.analysis;
+
+import java.io.IOException;
+
+import org.codehaus.commons.compiler.CompileException;
+import org.codehaus.janino.Parser;
+import org.codehaus.janino.Scanner;
+import org.codehaus.janino.Scanner.Token;
+
+public class CustomParser extends Parser {
+
+	public CustomParser(Scanner s){
+		super(s);
+	}
+	
+	/**
+     * @return The value of the next token, which is an indentifier
+     * @throws CompileException The next token is not an identifier
+     * 
+     * The modification here aims to consume @Collection Annotation from method identifiers
+     * to avoid Parsing exceptions! Thats the only way to collect method annotations!
+     */
+	@Override
+    public String readIdentifier() throws CompileException, IOException {
+        Token t = this.read();
+        if(t.toString().contains( "@") && this.peekRead("Collection")){
+        	//System.out.println("Found Collection Annotation at Line: "+ t.getLocation().getLineNumber());
+        	AnnotationAnalysis.addCustomParserCollectionAnnotation(t.getLocation().getLineNumber(), "Collection");
+        	return this.read().value;
+        }
+        
+        if (t.type != Token.IDENTIFIER) throw this.compileException("Identifier expected instead of '" + t.value + "'");
+        
+        return t.value;
+    }
+
+}

--- a/seep-java2sdg/src/test/java/Fake.java
+++ b/seep-java2sdg/src/test/java/Fake.java
@@ -1,6 +1,7 @@
 import java.util.ArrayList;
 import java.util.List;
 
+import uk.ac.imperial.lsds.seep.api.annotations.Collection;
 import uk.ac.imperial.lsds.seep.api.annotations.Global;
 import uk.ac.imperial.lsds.seep.api.annotations.NetworkSource;
 import uk.ac.imperial.lsds.seep.api.annotations.Partial;
@@ -32,7 +33,7 @@ public class Fake {
 		return weights.get(0);
 	}
 	
-	public void test(float data){
+	public void test(@Collection float data){
 		int a = 0;
 		@NetworkSource(endpoint="kafka://localhost:5555")
 		int b = 1;


### PR DESCRIPTION
After trying a variety of different approaches I am now convinced that Janino Parser does not accept Annotations as method parameters (either declarations or calls)!
Overriding any Traverser method can not help since the Parser has specific rules that you cannot bypass. The only clean solution is to "consume" the extra annotation inside the Parser as implemented below.
When the annotation is identified the parser calls a static method in the AnnotationAnalysis class to add the annotation in the list!
Code tested and working (should be also merged with the new SDGAnnotation Enum Implementation)
