### PR TITLE
Command line arguments fix

### DIFF
--- a/seep-common/src/main/java/uk/ac/imperial/lsds/seep/config/ConfigKey.java
+++ b/seep-common/src/main/java/uk/ac/imperial/lsds/seep/config/ConfigKey.java
@@ -27,7 +27,12 @@ public class ConfigKey {
         this.documentation = documentation;
     }
 
+    public String getName(){
+    	return this.name;
+    }
+    
     public boolean hasDefault() {
         return this.defaultValue != NO_DEFAULT_VALUE;
     }
+    
 }

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
@@ -83,10 +83,10 @@ public class Main {
 		Properties commandLineProperties = cla.getProperties();
 		
 		// Get Properties with file configuration
-		Properties fileProperties = Utils.readPropertiesFromFile(MasterConfig.PROPERTIES_FILE, MasterConfig.PROPERTIES_RESOURCE_FILE);
+		Properties fileProperties = Utils.readPropertiesFromFile(cla.getProperties().getProperty(MasterConfig.PROPERTIES_FILE), MasterConfig.PROPERTIES_RESOURCE_FILE);
 		
 		// Merge both properties, command line has preference
-		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(commandLineProperties, fileProperties);
+		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(fileProperties, commandLineProperties);
 		boolean validates = validateProperties(validatedProperties);
 		if(!validates){
 			printHelp(parser);

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
@@ -86,7 +86,7 @@ public class Main {
 		Properties fileProperties = Utils.readPropertiesFromFile(cla.getProperties().getProperty(MasterConfig.PROPERTIES_FILE), MasterConfig.PROPERTIES_RESOURCE_FILE);
 		
 		// Merge both properties, command line has preference
-		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(commandLineProperties, fileProperties);
+		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(commandLineProperties, fileProperties, configKeys);
 		boolean validates = validateProperties(validatedProperties);
 		if(!validates){
 			printHelp(parser);

--- a/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
+++ b/seep-master/src/main/java/uk/ac/imperial/lsds/seepmaster/Main.java
@@ -86,7 +86,7 @@ public class Main {
 		Properties fileProperties = Utils.readPropertiesFromFile(cla.getProperties().getProperty(MasterConfig.PROPERTIES_FILE), MasterConfig.PROPERTIES_RESOURCE_FILE);
 		
 		// Merge both properties, command line has preference
-		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(fileProperties, commandLineProperties);
+		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(commandLineProperties, fileProperties);
 		boolean validates = validateProperties(validatedProperties);
 		if(!validates){
 			printHelp(parser);

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
@@ -114,7 +114,7 @@ public class Main {
 		// Get properties from file, if any
 		Properties fileProperties = Utils.readPropertiesFromFile(cla.getProperties().getProperty(WorkerConfig.PROPERTIES_FILE), WorkerConfig.PROPERTIES_RESOURCE_FILE);
 		
-		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(commandLineProperties, fileProperties);
+		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(commandLineProperties, fileProperties, configKeys);
 		boolean validates = validateProperties(validatedProperties);
 		if(!validates){
 			printHelp(parser);

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
@@ -114,7 +114,7 @@ public class Main {
 		// Get properties from file, if any
 		Properties fileProperties = Utils.readPropertiesFromFile(cla.getProperties().getProperty(WorkerConfig.PROPERTIES_FILE), WorkerConfig.PROPERTIES_RESOURCE_FILE);
 		
-		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(fileProperties, commandLineProperties);
+		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(commandLineProperties, fileProperties);
 		boolean validates = validateProperties(validatedProperties);
 		if(!validates){
 			printHelp(parser);

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
@@ -112,9 +112,9 @@ public class Main {
 		Properties commandLineProperties = cla.getProperties();
 		
 		// Get properties from file, if any
-		Properties fileProperties = Utils.readPropertiesFromFile(WorkerConfig.PROPERTIES_FILE, WorkerConfig.PROPERTIES_RESOURCE_FILE);
+		Properties fileProperties = Utils.readPropertiesFromFile(cla.getProperties().getProperty(WorkerConfig.PROPERTIES_FILE), WorkerConfig.PROPERTIES_RESOURCE_FILE);
 		
-		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(commandLineProperties, fileProperties);
+		Properties validatedProperties = Utils.overwriteSecondPropertiesWithFirst(fileProperties, commandLineProperties);
 		boolean validates = validateProperties(validatedProperties);
 		if(!validates){
 			printHelp(parser);


### PR DESCRIPTION
- Problem: I wanted to run a seep-wroker or a seep-master from command line using a static configuration file like: ./seep-worker --properties.file=/home/pg1712/my-config/worker1.properties. As it tourned out the properties file was not being read because by default it was expecting a local file with name properties.file. 
- Solution: I fixed that reading the prorties-filename form the command line, given by the user and then changed the file priorities to have higher priority than command line arguments - otherwise they are going to be ignored every time! I am not sure what was the idea here but the way it works now makes more sense  to me.
