### PR TITLE
Worker Local ip fix

### DIFF
--- a/seep-common/src/main/java/uk/ac/imperial/lsds/seep/util/Utils.java
+++ b/seep-common/src/main/java/uk/ac/imperial/lsds/seep/util/Utils.java
@@ -8,11 +8,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.UnknownHostException;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
 
@@ -170,6 +174,29 @@ public class Utils {
 			e.printStackTrace();
 		}
 		return myIp;
+	}
+	
+	public static InetAddress getPublicIp(){
+		InetAddress myIp = null;
+		try {
+            Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            while (networkInterfaces.hasMoreElements()) {
+                NetworkInterface ni = (NetworkInterface) networkInterfaces.nextElement();
+                Enumeration<InetAddress> nias = ni.getInetAddresses();
+                while(nias.hasMoreElements()) {
+                    myIp = (InetAddress) nias.nextElement();
+                    if (!myIp.isLinkLocalAddress() 
+                     && !myIp.isLoopbackAddress()
+                     && myIp instanceof Inet4Address) {
+                    	LOG.debug("Public-local IP is {} - {} interface", myIp, ni.getName() );
+                        return myIp;
+                    }
+                }
+            }
+        } catch (SocketException e) {
+            LOG.error("Unable to get public-local IP " + e.getMessage(), e);
+        }
+        return null;
 	}
 	
 	public static int utf8Length(CharSequence s) {

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
@@ -55,9 +55,9 @@ public class Main {
 		int myPort = wc.getInt(WorkerConfig.LISTENING_PORT);
 		int dataPort = wc.getInt(WorkerConfig.DATA_PORT);
 		int controlPort = wc.getInt(WorkerConfig.CONTROL_PORT);
-		// If no IP is given, then find some local address
+		// If no IP is given, then find the local-public address
 		if(myIp == null) {
-			myIp = Utils.getLocalIp();
+			myIp = Utils.getPublicIp();
 		}
 		
 		// Create comm object

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/Main.java
@@ -51,15 +51,16 @@ public class Main {
 		
 		// Read configs with info about IP and port to bind to
 		String myIpStr = wc.getString(WorkerConfig.LISTENING_IP);
-		InetAddress myIp = Utils.getIpFromStringRepresentation(myIpStr);//InetAddress.getByName(myIpStr);
 		int myPort = wc.getInt(WorkerConfig.LISTENING_PORT);
 		int dataPort = wc.getInt(WorkerConfig.DATA_PORT);
 		int controlPort = wc.getInt(WorkerConfig.CONTROL_PORT);
 		// If no IP is given, then find the local-public address
-		if(myIp == null) {
+		InetAddress myIp = null;
+		if(myIpStr == "")
 			myIp = Utils.getPublicIp();
-		}
-		
+		else
+			myIp = Utils.getIpFromStringRepresentation(myIpStr);//InetAddress.getByName(myIpStr);
+			
 		// Create comm object
 		Comm comm = new IOComm(new JavaSerializer(), Executors.newCachedThreadPool());
 		


### PR DESCRIPTION
Worker Local ip fix to avoid sending loopback (127.0.0.1) address to the Master. This used to happen when the user did not specify the worker public ip. I did something more clever, iterating through the network interfaces and determining which is the more appropriate non-loopback address to send.
