### PR TITLE
Fixed the failed import of MockChannel

### DIFF
--- a/seep-integrationtests/build.gradle
+++ b/seep-integrationtests/build.gradle
@@ -5,4 +5,7 @@ dependencies {
 	compile project(':seep-worker')
 	compile project(':seep-contrib')
 	compile project(':seep-java2sdg')
+
+	compile project(':seep-worker').sourceSets.test.output
+	compile 'junit:junit:4.11'
 }


### PR DESCRIPTION
@raulcf This was causing the project to fail to compile

The only fix that's required is build.gradle but I removed trailing whitespaces and optimised imports on the failing test, which I'm happy to remove if you want.
