### PR TITLE
FIX for ISSUE #63: SchemaParser breaks serialization

### DIFF
--- a/seep-common/src/main/java/uk/ac/imperial/lsds/seep/api/data/Schema.java
+++ b/seep-common/src/main/java/uk/ac/imperial/lsds/seep/api/data/Schema.java
@@ -190,7 +190,7 @@ public class Schema {
 	}
 	
 	private static class DefaultParser implements SchemaParser {
-		private Charset encoding = Charset.defaultCharset();
+		private String encoding = Charset.defaultCharset().name();
 		private static DefaultParser instance = null;		
 
 		private DefaultParser(){}
@@ -203,7 +203,7 @@ public class Schema {
 		}
 		
 		public byte[] bytesFromString(String textRecord) {
-			byte[] byteline = textRecord.getBytes(encoding);
+			byte[] byteline = textRecord.getBytes(Charset.forName(encoding));
 			ByteBuffer b = ByteBuffer.allocate((Integer.SIZE/Byte.SIZE) + byteline.length);
 			b.putInt(byteline.length);
 			b.put(byteline);
@@ -216,11 +216,11 @@ public class Schema {
 			return new String(wrapper.array());
 		}
 		
-		public Charset getCharset() {
+		public String getCharsetName() {
 			return encoding;
 		}
 		
-		public void setCharset(Charset newencoding) {
+		public void setCharset(String newencoding) {
 			encoding = newencoding;
 		}
 	}

--- a/seep-common/src/main/java/uk/ac/imperial/lsds/seep/api/data/SchemaParser.java
+++ b/seep-common/src/main/java/uk/ac/imperial/lsds/seep/api/data/SchemaParser.java
@@ -1,10 +1,8 @@
 package uk.ac.imperial.lsds.seep.api.data;
 
-import java.nio.charset.Charset;
-
 public interface SchemaParser {
 	public byte[] bytesFromString(String textRecord);
 	public String stringFromBytes(byte[] binaryRecord);
-	public Charset getCharset();
-	public void setCharset(Charset newencoding);
+	public String getCharsetName();
+	public void setCharset(String newencoding);
 }

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/FileSelector.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/FileSelector.java
@@ -260,7 +260,7 @@ public class FileSelector implements DataStoreSelector {
 		}
 		
 		private void readFromText(Entry<SeekableByteChannel, Integer> e, IBuffer ib, ReadableByteChannel rbc) {
-			BufferedReader br = new BufferedReader (Channels.newReader(rbc, channelDataStore.get(e.getValue()).getSchema().getSchemaParser().getCharset().name()));
+			BufferedReader br = new BufferedReader (Channels.newReader(rbc, channelDataStore.get(e.getValue()).getSchema().getSchemaParser().getCharsetName()));
 			String line;
 			try {
 				while ((line = br.readLine()) != null) {


### PR DESCRIPTION
Changed the SchemaParser class to use the String name instead of the
Charset class so serialization works. Updates the defaultParser class in
Schema and the stuff in FileSelector to work with the change.
