### PR TITLE
Added caching capabilities to Datasets.

### DIFF
--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DataReferenceManager.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DataReferenceManager.java
@@ -1,5 +1,7 @@
 package uk.ac.imperial.lsds.seepworker.core;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,6 +121,25 @@ public class DataReferenceManager {
 			if(dss.type() == type) return dss;
 		}
 		return null;
+	}
+	
+	public void sendDatasetToDisk(int datasetId) throws IOException {
+		LOG.info("Caching Dataset to disk, id -> {}", datasetId);
+		datasets.get(datasetId).cacheToDisk();
+		LOG.info("Finished caching Dataset to disk, id -> {}", datasetId);
+	}
+	
+	public int retrieveDatasetFromDisk(int datasetId) {
+		try {
+			LOG.info("Returning cached Dataset to memory, id -> {}", datasetId);
+			return datasets.get(datasetId).retrieveFromDisk();
+		} finally {
+			LOG.info("Finished returning cached Dataset to memory, id -> {}", datasetId);
+		}
+	}
+	
+	public boolean datasetIsInMem(int datasetId) {
+		return datasets.get(datasetId).inMem();
 	}
 
 	public IBuffer getInputBufferFor(DataReference dr) {

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DataReferenceManager.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DataReferenceManager.java
@@ -155,7 +155,7 @@ public class DataReferenceManager {
 	public IBuffer getSyntheticDataset(DataReference dr) {
 		
 		// TODO: basic generation of data
-		ByteBuffer d = ByteBuffer.allocate(99);//3999);
+		ByteBuffer d = ByteBuffer.allocate(3999);
 		
 		// Generate synthetic data
 		Schema s = dr.getDataStore().getSchema();

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/Dataset.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/Dataset.java
@@ -256,7 +256,7 @@ public class Dataset implements IBuffer, OBuffer {
 				
 				wPtrToBuffer.putInt(recordSize);
 				wPtrToBuffer.put(record);
-				System.out.println(returnedTuples++);
+				returnedTuples++;
 			}
 			inputStream.close();
 			try {

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/Dataset.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/Dataset.java
@@ -1,8 +1,15 @@
 package uk.ac.imperial.lsds.seepworker.core;
 
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -25,6 +32,7 @@ public class Dataset implements IBuffer, OBuffer {
 	private Iterator<ByteBuffer> readerIterator;
 	private ByteBuffer wPtrToBuffer;
 	private ByteBuffer rPtrToBuffer;
+	private String cacheFileName = "";
 
 	public Dataset(DataReference dataReference, BufferPool bufferPool) {
 		this.dataReference = dataReference;
@@ -61,18 +69,32 @@ public class Dataset implements IBuffer, OBuffer {
 		if(rPtrToBuffer == null || rPtrToBuffer.remaining() == 0) {
 			// When the buffer is read completely we return it to the pool
 			if(rPtrToBuffer != null) {
+				readerIterator.remove();
 				bufferPool.returnBuffer(rPtrToBuffer);
 			}
 			if(readerIterator.hasNext()) {
 				rPtrToBuffer = readerIterator.next();
 				rPtrToBuffer.flip();
+				
+				if (!readerIterator.hasNext()) {
+					//We caught up to the write buffer. Allocate a new buffer for writing
+					this.wPtrToBuffer = bufferPool.borrowBuffer();
+					this.buffers.add(wPtrToBuffer);
+					//Yes, the following looks a bit silly, but it is necessary to allow
+					//readerIterator.remove to work without the iterator complaining
+					//about concurrent modification
+					readerIterator = this.buffers.iterator();
+					rPtrToBuffer = readerIterator.next();
+					if (rPtrToBuffer.remaining() == 0) {
+						return null;
+					}
+				}
 			}
 			else {
 				// done reading
 				return null;
 			}
 		}
-		
 		int size = rPtrToBuffer.getInt();
 		byte[] data = new byte[size];
 		rPtrToBuffer.get(data);
@@ -106,6 +128,24 @@ public class Dataset implements IBuffer, OBuffer {
 	
 	@Override
 	public boolean write(byte[] data) {
+		if (!cacheFileName.equals("")) {
+			//If this dataset has been cached to disk write the data there instead of using up memory
+			try {
+				DataOutputStream cacheStream = new DataOutputStream(new FileOutputStream(cacheFileName, true));
+				cacheStream.writeInt(data.length);
+				cacheStream.write(data);
+				cacheStream.flush();
+				cacheStream.close();
+				return true;
+			} catch (FileNotFoundException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			} catch (IOException ioe) {
+				// TODO Auto-generated catch block
+				ioe.printStackTrace();
+			}
+			return false;
+		}
 		
 		int dataSize = data.length;
 		if(wPtrToBuffer.remaining() < dataSize + TupleInfo.TUPLE_SIZE_OVERHEAD) {
@@ -148,4 +188,104 @@ public class Dataset implements IBuffer, OBuffer {
 		
 	}
 	
+	public void cacheToDisk() throws FileNotFoundException, IOException {
+		if (!cacheFileName.equals("")) {
+			//Already on disk. Claim victory and move on.
+			return;
+		}
+		//Changing to abs might lead to a conflict (HIGHLY unlikely, needs a DataSet with the opposite 
+		//ID cached at exactly the same time), but files that start with - are annoying in console
+		//debugging.
+		cacheFileName = Math.abs(id) + "_" + System.currentTimeMillis() + ".cached";
+		try {
+			DataOutputStream cacheStream = new DataOutputStream(new FileOutputStream(cacheFileName));
+			byte[] record;
+			while((record = consumeData()) != null) {
+				cacheStream.writeInt(record.length);
+				cacheStream.write(record);
+			}
+			cacheStream.flush();
+			cacheStream.close();
+		} catch (FileNotFoundException fnfe) {
+			cacheFileName = "";
+			fnfe.printStackTrace();
+			throw fnfe;
+		} catch (IOException ioe) {
+			//Assume nothing got cached. This isn't a particularly safe assumption, but it's probably
+			//more likely than something was cached and we have a split dataset.
+			cacheFileName = "";
+			ioe.printStackTrace();
+			throw ioe;
+		} catch (SecurityException e) {
+			cacheFileName = "";
+			//Yes, technically throwing the SecurityException would be more descriptive, but the end result is the same,
+			//and handling only one type of exception is easier at the higher levels.
+			FileNotFoundException toThrow = new FileNotFoundException("Security settings prevent the file from being created");
+			toThrow.fillInStackTrace();
+			toThrow.printStackTrace();
+			throw toThrow;
+		}
+	}
+	
+	public int retrieveFromDisk() {
+		if (cacheFileName.equals("")) {
+			//No file on disk, so exactly zero ITuples can be returned to memory.
+			return 0;
+		}
+		FileInputStream inputStream  = null;
+		int returnedTuples = 0;
+		try {
+			//It is used, in the while condition just below, but Eclipse's analyzer isn't 
+			//smart enough to figure that out. This just saves us a warning.
+			@SuppressWarnings("unused")
+			int readSuccess;
+			inputStream = new FileInputStream(cacheFileName);
+			byte[] recordSizeBytes = new byte[Integer.SIZE / Byte.SIZE];
+			//If there is another record the next few bytes will be an int containing the size of said record.
+			while ((readSuccess = inputStream.read(recordSizeBytes)) != -1) {
+				//Convert the bytes giving us the size to an int and read exactly the next record
+				int recordSize = ByteBuffer.wrap(recordSizeBytes).getInt();
+				byte[] record = new byte[recordSize];
+				inputStream.read(record);
+				
+				if(wPtrToBuffer.remaining() < recordSize + TupleInfo.TUPLE_SIZE_OVERHEAD) {
+					// Borrow a new buffer and add to the collection
+					this.wPtrToBuffer = bufferPool.borrowBuffer();
+					this.buffers.add(wPtrToBuffer);
+				}
+				
+				wPtrToBuffer.putInt(recordSize);
+				wPtrToBuffer.put(record);
+				System.out.println(returnedTuples++);
+			}
+			inputStream.close();
+			try {
+				Files.delete((new File(cacheFileName)).toPath());
+			} catch (IOException ioex) {
+				//This isn't good, but failing to clean up is different from not being able
+				//to read everything, so we still consider this a success.
+				//ioex.printStackTrace();
+			}
+			cacheFileName = "";
+			return returnedTuples;
+		} catch (FileNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (IOException ioe) {
+			// TODO Auto-generated catch block
+			ioe.printStackTrace();
+		} 
+		try {
+			if (inputStream != null) {
+				inputStream.close();
+			}
+		} catch (IOException ex) {
+			
+		}
+		return returnedTuples;
+	}
+	
+	public boolean inMem() {
+		return cacheFileName.equals("");
+	}
 }

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DiskCacher.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DiskCacher.java
@@ -1,0 +1,172 @@
+package uk.ac.imperial.lsds.seepworker.core;
+
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+
+/***
+ * Class to move Datasets between disk and memory, as requested (by the DataReferenceManager).
+ * @author iv
+ *
+ */
+public class DiskCacher {
+	private Map<Integer, String> filenames;
+	private static DiskCacher instance;
+	
+	private DiskCacher() {
+		filenames = new HashMap<Integer, String>();
+	}
+
+	public static DiskCacher makeDiskCacher() {
+		if(instance == null) {
+			instance = new DiskCacher();
+		}
+		return instance;
+	}
+	
+	/***
+	 * Moves a Dataset to disk. If the Dataset is already on disk we try to move everything to
+	 * disk anyway. This is because there can be some rare instances with multithreading when
+	 * a Dataset can retain something in memory after being sent to disk. Two calls to this
+	 * function solve that if the user wants to be sure (subsequent calls do nothing), although
+	 * there is no guarantee on the order of records.
+	 * @param data
+	 * @throws FileNotFoundException
+	 * @throws IOException
+	 * @return The number of records sent to disk.
+	 */
+	public int cacheToDisk(Dataset data) throws FileNotFoundException, IOException {
+		String cacheFileName = "";
+		int cachedRecords = 0;
+		//if(data.id() == null) {System.out.println("ID");}
+		if (filenames.containsKey(data.id())) {
+			//Already on disk. We could claim victory and return, but this will allow us to cache any
+			//items stuck in memory (see comment below).
+			cacheFileName = filenames.get(data.id());
+		} else {
+			//Changing to abs might lead to a conflict (HIGHLY unlikely, needs a DataSet with the opposite 
+			//ID cached at exactly the same time), but files that start with - are annoying in console
+			//debugging.
+			cacheFileName = Math.abs(data.id()) + "_" + System.currentTimeMillis() + ".cached";
+			filenames.put(data.id(), cacheFileName);
+		}
+		try {
+			DataOutputStream cacheStream = new DataOutputStream(new FileOutputStream(cacheFileName));
+			byte[] record;
+			while((record = data.consumeData()) != null) {
+				cacheStream.writeInt(record.length);
+				cacheStream.write(record);
+				cachedRecords++;
+			}
+			cacheStream.flush();
+			cacheStream.close();
+			//Setting this late makes the implementation thread safe-ish. Any writes to the Dataset will
+			//start going to the file NOW, so it won't try to write to disk at the same time as this function.
+			//HOWEVER, any writes that happened between the last write and now will be stuck in memory.
+			//A second call to cacheToDisk can solve this, although data might be reordered if Dataset.write
+			//is called in the meantime.
+			data.setCachedLocation(cacheFileName);
+		} catch (FileNotFoundException fnfe) {
+			cacheFileName = "";
+			fnfe.printStackTrace();
+			throw fnfe;
+		} catch (IOException ioe) {
+			//Assume nothing got cached. This isn't a particularly safe assumption, but it's probably
+			//more likely than something was cached and we have a split dataset.
+			cacheFileName = "";
+			ioe.printStackTrace();
+			throw ioe;
+		} catch (SecurityException e) {
+			cacheFileName = "";
+			//Yes, technically throwing the SecurityException would be more descriptive, but the end result is the same,
+			//and handling only one type of exception is easier at the higher levels.
+			FileNotFoundException toThrow = new FileNotFoundException("Security settings prevent the file from being created");
+			toThrow.fillInStackTrace();
+			toThrow.printStackTrace();
+			throw toThrow;
+		}
+		return cachedRecords;
+	}
+	
+	/***
+	 * Returns a Dataset from disk to memory.
+	 * @param data
+	 * @return The number of records returned to memory.
+	 */
+	public int retrieveFromDisk(Dataset data) {
+		if (!filenames.containsKey(data.id())) {
+			//No file on disk, so exactly zero ITuples can be returned to memory.
+			return 0;
+		}
+		FileInputStream inputStream  = null;
+		int returnedTuples = 0;
+		String cacheFileName = filenames.get(data.id());
+		try {
+			//Unsetting this first is necessary - otherwise the write we use to place the record
+			//back in memory will just be appended back to the file.
+			data.unsetCachedLocation();
+			//It is used, in the while condition just below, but Eclipse's analyzer isn't 
+			//smart enough to figure that out. This just saves us a warning.
+			@SuppressWarnings("unused")
+			int readSuccess;
+			inputStream = new FileInputStream(cacheFileName);
+			byte[] recordSizeBytes = new byte[Integer.SIZE / Byte.SIZE];
+			//If there is another record the next few bytes will be an int containing the size of said record.
+			while ((readSuccess = inputStream.read(recordSizeBytes)) != -1) {
+				//Convert the bytes giving us the size to an int and read exactly the next record
+				int recordSize = ByteBuffer.wrap(recordSizeBytes).getInt();
+				byte[] record = new byte[recordSize + Integer.SIZE / Byte.SIZE];
+				System.arraycopy(recordSizeBytes, 0, record,0, Integer.SIZE / Byte.SIZE);
+				inputStream.read(record, Integer.SIZE / Byte.SIZE, recordSize);
+				
+				data.write(record);
+				returnedTuples++;
+			}
+			inputStream.close();
+			try {
+				Files.delete((new File(cacheFileName)).toPath());
+			} catch (IOException ioex) {
+				//This isn't good, but failing to clean up is different from not being able
+				//to read everything, so we still consider this a success.
+				//ioex.printStackTrace();
+			}
+			filenames.remove(data.id());
+			return returnedTuples;
+		} catch (FileNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (IOException ioe) {
+			// TODO Auto-generated catch block
+			ioe.printStackTrace();
+		} 
+		if (filenames.containsKey(data.id())) {
+			data.setCachedLocation(filenames.get(data.id()));
+		}
+		try {
+			if (inputStream != null) {
+				inputStream.close();
+			}
+		} catch (IOException ex) {
+			
+		}
+		return returnedTuples;
+	}
+	
+	/***
+	 * Check if a Dataset is currently entirely in memory (or conversely, 
+	 * (perhaps partially in the case of multithreading) on disk).
+	 * @param data
+	 * @return true if data is in memory.
+	 */
+	public boolean inMem(Dataset data) {
+		return (!(filenames.containsKey(data.id())));
+	}
+
+}

--- a/seep-worker/src/test/java/uk/ac/imperial/lsds/seepworker/core/DiskCacherTest.java
+++ b/seep-worker/src/test/java/uk/ac/imperial/lsds/seepworker/core/DiskCacherTest.java
@@ -1,0 +1,134 @@
+package uk.ac.imperial.lsds.seepworker.core;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import uk.ac.imperial.lsds.seep.api.DataReference;
+import uk.ac.imperial.lsds.seep.api.DataReference.ServeMode;
+import uk.ac.imperial.lsds.seep.api.data.Schema;
+import uk.ac.imperial.lsds.seep.api.data.Type;
+import uk.ac.imperial.lsds.seepworker.WorkerConfig;
+
+public class DiskCacherTest {
+	Schema s = Schema.SchemaBuilder.getInstance().newField(Type.INT, "counter").build();
+	int ownerCounter = 0;
+
+	private WorkerConfig buildWorkerConfig() {
+		Properties p = new Properties();
+		p.setProperty(WorkerConfig.MASTER_IP, "");
+		p.setProperty(WorkerConfig.PROPERTIES_FILE, "");
+		p.setProperty(WorkerConfig.SIMPLE_INPUT_QUEUE_LENGTH, "100");
+		p.setProperty(WorkerConfig.LISTENING_IP, "");
+		
+		return new WorkerConfig(p);
+	}
+
+	/***
+	 * Simple test that creates a Dataset attached to a DataReferenceManager, 
+	 * then checks that said DataReferenceManager successfully tracks when the
+	 * Dataset resides in memory and when it has been pushed to disk.
+	 */
+	@Test
+	public void testInMemCall() {
+		//make new Dataset
+		DataReferenceManager drm = DataReferenceManager.makeDataReferenceManager(buildWorkerConfig());
+		DataReference dataRef = DataReference.makeManagedDataReferenceWithOwner(ownerCounter++, null, null, ServeMode.STORE);
+		Dataset testDataset = (Dataset) drm.manageNewDataReference(dataRef);
+		//new Datasets should reside in memory.
+		assert(drm.datasetIsInMem(testDataset.id()) == true);
+		//cache the Dataset and check that the in memory tracker is updated
+		try {
+			drm.sendDatasetToDisk(testDataset.id());
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		assert(drm.datasetIsInMem(testDataset.id()) == false);
+		//return the Dataset to memory and check that the in memory tracker is updated again
+		drm.retrieveDatasetFromDisk(testDataset.id());
+		assert(drm.datasetIsInMem(testDataset.id()) == true);
+	}
+
+	/***
+	 * Tests that the mechanism to cache a Dataset already in memory to disk 
+	 * actually works. A Dataset is populated, then cached to disk. At this 
+	 * point the call to consume the next record in the Dataset should return
+	 * null (the expected behavior when the Dataset has nothing in memory). If
+	 * the Dataset is then uncached and the next item read it should be the
+	 * first item in the Dataset.
+	 */
+	@Test
+	public void testMemToDisk() {
+		//make and populate a new Dataset
+		DataReferenceManager drm = DataReferenceManager.makeDataReferenceManager(buildWorkerConfig());
+		DataReference dataRef = DataReference.makeManagedDataReferenceWithOwner(ownerCounter++, null, null, ServeMode.STORE);
+		Dataset testDataset = (Dataset) drm.manageNewDataReference(dataRef);
+		for (int x = 0; x < 10; x++) {
+			ByteBuffer writeData = ByteBuffer.allocate((Integer.SIZE/Byte.SIZE) * 2);
+			writeData.putInt((new Integer(Integer.SIZE/Byte.SIZE)));
+			writeData.putInt(x);
+			testDataset.write(writeData.array());
+		}
+		//cache dataset and check the caching was successful
+		try {
+			drm.sendDatasetToDisk(testDataset.id());
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		assert(testDataset.consumeData() == null);
+		//uncache dataset and check everything reappeared (and nothing else)
+		drm.retrieveDatasetFromDisk(testDataset.id());
+		for (int x = 0; x < 10; x++) {
+			ByteBuffer readData = ByteBuffer.allocate((Integer.SIZE/Byte.SIZE) * 2);
+			readData.put(testDataset.consumeData());
+			readData.getInt();
+			assert(readData.getInt() == x);
+		}
+		assert(testDataset.consumeData() == null);
+	}
+
+
+	/***
+	 * Tests that the mechanism to cache a Dataset correctly redirects future
+	 * items written to the Dataset to disk. A Dataset is created, cached to
+	 * disk, then populated. At this point the call to consume the next record 
+	 * in the Dataset should return null (the expected behavior when the Dataset
+	 * has nothing in memory). If the Dataset is then uncached and the next item
+	 * read it should be the first item in the Dataset.
+	 */
+	@Test
+	public void testFutureToDisk() {
+		//make, cache, and populate a new Dataset
+		DataReferenceManager drm = DataReferenceManager.makeDataReferenceManager(buildWorkerConfig());
+		DataReference dataRef = DataReference.makeManagedDataReferenceWithOwner(ownerCounter++, null, null, ServeMode.STORE);
+		Dataset testDataset = (Dataset) drm.manageNewDataReference(dataRef);
+		try {
+			drm.sendDatasetToDisk(testDataset.id());
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		for (int x = 0; x < 10; x++) {
+			ByteBuffer writeData = ByteBuffer.allocate((Integer.SIZE/Byte.SIZE) * 2);
+			writeData.putInt((new Integer(Integer.SIZE/Byte.SIZE)));
+			writeData.putInt(x);
+			testDataset.write(writeData.array());
+		}
+		//check the caching was successful
+		assert(testDataset.consumeData() == null);
+		//uncache dataset and check everything reappeared (and nothing else)
+		drm.retrieveDatasetFromDisk(testDataset.id());
+		for (int x = 0; x < 10; x++) {
+			ByteBuffer readData = ByteBuffer.allocate((Integer.SIZE/Byte.SIZE) * 2);
+			readData.put(testDataset.consumeData());
+			readData.getInt();
+			assert(readData.getInt() == x);
+		}
+		assert(testDataset.consumeData() == null);
+	}
+
+}


### PR DESCRIPTION
Added the ability to write a dataset to disk (freeing up the associated
memory used to store the content, but not the metadata), return a
Dataset from disk to memory, and check if a Dataset is currently in
memory (or conversely, on disk). When a Dataset is on disk subsequent
additions are appended to the file containing the data rather than
storing them in memory. All three functions are wrapped in the
DataReferenceManager as well so changes can be made using the Dataset
identifier instead of requiring a pointer directly to the Dataset.
