### PR TITLE
(Un)caching Improvements

### DIFF
--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/Dataset.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/Dataset.java
@@ -1,8 +1,6 @@
 package uk.ac.imperial.lsds.seepworker.core;
 
-import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.DataOutputStream;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -148,27 +146,21 @@ public class Dataset implements IBuffer, OBuffer {
 		return freedMemory;
 	}
 	
-	public void transferToMemory(BufferedInputStream bis, int bbSize) {
+	public void transferToMemory(ReadableByteChannel bis) {
 		boolean goOn = true;
 		while(goOn) {
 			int limit = 0;
 			ByteBuffer bb = null;
 			try {
-				limit = bis.read();
-				if(limit == -1) {
-					goOn = false;
-					bis.close();
-					continue;
-				}
 				bb = bufferPool.borrowBuffer();
 				int read = 0;
 				if(bb == null) { // Run out of memory, we can try with the cached buffer
-					read = bis.read(wPtrToBuffer.array());
+					read = bis.read(wPtrToBuffer);
 				}
 				else {
-					read = bis.read(bb.array());
+					read = bis.read(bb);
 				}
-				if(read == -1) {
+				if(read <= 0) {
 					goOn = false;
 					bufferPool.returnBuffer(bb);
 					bis.close();

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DiskCacher.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DiskCacher.java
@@ -7,6 +7,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -86,6 +87,7 @@ public class DiskCacher {
 		
 		while(buffers.hasNext()) {
 			ByteBuffer bb = buffers.next();
+			//TODO: Is this line necessary? Or should it first be checked to see if bb was already flipped?
 			bb.flip();
 			ByteBuffer size = ByteBuffer.allocate(Integer.BYTES).putInt(bb.limit());
 			writer.write(size);
@@ -110,10 +112,9 @@ public class DiskCacher {
 		// Prepare dataset for trasnfer to memory
 		ByteBuffer currentPointer = data.prepareForTransferToMemory();
 		
-		int bbSize = wc.getInt(WorkerConfig.BUFFERPOOL_MIN_BUFFER_SIZE);
-		BufferedInputStream bis = new BufferedInputStream(new FileInputStream(cacheFileName), bbSize);
-
-		data.transferToMemory(bis, bbSize);
+		ReadableByteChannel reader = Channels.newChannel(new FileInputStream(cacheFileName));
+		
+		data.transferToMemory(reader);
 		
 		data.completeTransferToMemory(currentPointer);
 		


### PR DESCRIPTION
Replaces the buffered streams with byte channels. Time to run the mb (with IDX and createUnsafe) with 5 GB input/machine drops from 14.1 minutes to 8.5.

I still haven't completely tested stability yet. In particular I'm not sure how to test if bb.flip() (DiskCacher, line 91) is correct.
