### PR TITLE
Fix runaway memory allocation.

### DIFF
--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/BufferPool.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/BufferPool.java
@@ -29,6 +29,8 @@ public class BufferPool {
 	// released immediately. However, effectively, the total memory available would be
 	// the total_memory_available - usedMemory
 	final private Counter usedMemory;
+	//keep track of all memory which was allocated for better bounds checking.
+	final private Counter allocatedMemory;
 	
 	public static BufferPool __TEMPORAL_FAKE() {
 		return new BufferPool(-666);
@@ -40,6 +42,7 @@ public class BufferPool {
 		this.allocatedBuffers = new ArrayDeque<ByteBuffer>();
 		LOG.warn("TEMPORAL-> dangling buffer pools");
 		usedMemory = SeepMetrics.REG.counter(name(BufferPool.class, "total", "mem"));
+		allocatedMemory = SeepMetrics.REG.counter(name(BufferPool.class, "allocated", "mem"));
 		preAllocatePoolOfBuffers();
 	}
 	
@@ -48,6 +51,7 @@ public class BufferPool {
 		this.totalMemAvailableToBufferPool = wc.getLong(WorkerConfig.BUFFERPOOL_MAX_MEM_AVAILABLE);
 		this.allocatedBuffers = new ArrayDeque<ByteBuffer>();
 		usedMemory = SeepMetrics.REG.counter(name(BufferPool.class, "event", "mem"));
+		allocatedMemory = SeepMetrics.REG.counter(name(BufferPool.class, "allocated", "mem"));
 		preAllocatePoolOfBuffers();
 		LOG.info("Created new Buffer Pool with availableMemory of {} and minBufferSize of: {}", this.totalMemAvailableToBufferPool, this.minBufferSize);
 	}
@@ -70,11 +74,13 @@ public class BufferPool {
 		if(allocatedBuffers.size() > 0) {
 			ByteBuffer bb = allocatedBuffers.pop();
 			bb.clear();
+			allocatedMemory.inc(minBufferSize);
 			usedMemory.inc(minBufferSize);
 			return bb;
 		}
 		else {
 			if(enoughMemoryAvailable()){
+				allocatedMemory.inc(minBufferSize);
 				usedMemory.inc(minBufferSize);
 				return allocateByteBuffer();
 			}
@@ -102,7 +108,7 @@ public class BufferPool {
 	
 	private boolean enoughMemoryAvailable() {
 		// Any headroom should have been incorporated on bufferPool creation (e.g. aprox. constant mem usage on steady state)
-		if(usedMemory.getCount() + minBufferSize > totalMemAvailableToBufferPool) {
+		if(allocatedMemory.getCount() + minBufferSize > totalMemAvailableToBufferPool) {
 			return false;
 		}
 		return true;
@@ -123,8 +129,9 @@ public class BufferPool {
 	
 	private void preAllocatePoolOfBuffers() {
 		LOG.info("Creating buffer pool... Pooling buffers");
-		while((allocatedBuffers.size() * this.minBufferSize) + this.minBufferSize < this.totalMemAvailableToBufferPool) {
+		while(allocatedMemory.getCount() + this.minBufferSize < this.totalMemAvailableToBufferPool) {
 			usedMemory.inc(minBufferSize);
+			allocatedMemory.inc(minBufferSize);
 			ByteBuffer n = this.allocateByteBuffer();
 			this.returnBuffer(n);
 		}

--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/BufferPool.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/BufferPool.java
@@ -43,7 +43,7 @@ public class BufferPool {
 		LOG.warn("TEMPORAL-> dangling buffer pools");
 		usedMemory = SeepMetrics.REG.counter(name(BufferPool.class, "total", "mem"));
 		allocatedMemory = SeepMetrics.REG.counter(name(BufferPool.class, "allocated", "mem"));
-		preAllocatePoolOfBuffers();
+		//preAllocatePoolOfBuffers();
 	}
 	
 	private BufferPool(WorkerConfig wc) {
@@ -52,7 +52,7 @@ public class BufferPool {
 		this.allocatedBuffers = new ArrayDeque<ByteBuffer>();
 		usedMemory = SeepMetrics.REG.counter(name(BufferPool.class, "event", "mem"));
 		allocatedMemory = SeepMetrics.REG.counter(name(BufferPool.class, "allocated", "mem"));
-		preAllocatePoolOfBuffers();
+		//preAllocatePoolOfBuffers();
 		LOG.info("Created new Buffer Pool with availableMemory of {} and minBufferSize of: {}", this.totalMemAvailableToBufferPool, this.minBufferSize);
 	}
 	


### PR DESCRIPTION
Added a new counter to keep track of memory _allocated_ in the buffer
pool. Using this gives us a little more precise metric and gets rid of
the out of memory errors that were plaguing deployments with more than
1GB of buffer space.
