### PR TITLE
Moved check for file's already being on disk.

### DIFF
--- a/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DiskCacher.java
+++ b/seep-worker/src/main/java/uk/ac/imperial/lsds/seepworker/core/DiskCacher.java
@@ -106,10 +106,10 @@ public class DiskCacher {
 	}
 	
 	public int cacheToDisk(Dataset data) throws FileNotFoundException, IOException {
-		String cacheFileName = getCacheFileName(data.id());
 		if (filenames.containsKey(data.id())) {
 			return 0;
 		}
+		String cacheFileName = getCacheFileName(data.id());
 		filenames.put(data.id(), cacheFileName);
 		
 		// Prepare channel


### PR DESCRIPTION
The code to get the filename for the eviction file automatically created
an entry in the (data id -> filename) map. This was done before checking
that map to see if we already evicted a dataset. As a result, it was
thought that every dataset was already evicted, and nothing ever
actually was, so all new datasets were created on disk.